### PR TITLE
Implement fetching artist/album info + identification

### DIFF
--- a/Jellyfin.Plugin.ITunes/Dtos/AlbumResult.cs
+++ b/Jellyfin.Plugin.ITunes/Dtos/AlbumResult.cs
@@ -5,7 +5,7 @@ namespace Jellyfin.Plugin.ITunes.Dtos
     /// <summary>
     /// Result.
     /// </summary>
-    public class Result
+    public class AlbumResult
     {
         /// <summary>
         /// Gets or sets the wrapper type.

--- a/Jellyfin.Plugin.ITunes/Dtos/ITunesAlbumDto.cs
+++ b/Jellyfin.Plugin.ITunes/Dtos/ITunesAlbumDto.cs
@@ -15,7 +15,7 @@ namespace Jellyfin.Plugin.ITunes.Dtos
         public ITunesAlbumDto()
         {
             ResultCount = 0;
-            Results = new List<Result>();
+            Results = new List<AlbumResult>();
         }
 
         /// <summary>
@@ -31,6 +31,6 @@ namespace Jellyfin.Plugin.ITunes.Dtos
         /// <value>The results.</value>
         [JsonPropertyName("results")]
         [SuppressMessage("Usage", "CA2227", Justification = "Setter is necessary for deserialization")]
-        public ICollection<Result> Results { get; set; }
+        public ICollection<AlbumResult> Results { get; set; }
     }
 }

--- a/Jellyfin.Plugin.ITunes/Dtos/ITunesAlbumDto.cs
+++ b/Jellyfin.Plugin.ITunes/Dtos/ITunesAlbumDto.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Jellyfin.Plugin.ITunes.Dtos
@@ -29,6 +30,7 @@ namespace Jellyfin.Plugin.ITunes.Dtos
         /// </summary>
         /// <value>The results.</value>
         [JsonPropertyName("results")]
+        [SuppressMessage("Usage", "CA2227", Justification = "Setter is necessary for deserialization")]
         public ICollection<Result> Results { get; set; }
     }
 }

--- a/Jellyfin.Plugin.ITunes/Dtos/ITunesAlbumDto.cs
+++ b/Jellyfin.Plugin.ITunes/Dtos/ITunesAlbumDto.cs
@@ -1,4 +1,4 @@
-using System;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Jellyfin.Plugin.ITunes.Dtos
@@ -8,6 +8,15 @@ namespace Jellyfin.Plugin.ITunes.Dtos
     /// </summary>
     public class ITunesAlbumDto
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ITunesAlbumDto"/> class.
+        /// </summary>
+        public ITunesAlbumDto()
+        {
+            ResultCount = 0;
+            Results = new List<Result>();
+        }
+
         /// <summary>
         /// Gets or sets the result count.
         /// </summary>
@@ -20,6 +29,6 @@ namespace Jellyfin.Plugin.ITunes.Dtos
         /// </summary>
         /// <value>The results.</value>
         [JsonPropertyName("results")]
-        public Result[] Results { get; set; } = Array.Empty<Result>();
+        public ICollection<Result> Results { get; set; }
     }
 }

--- a/Jellyfin.Plugin.ITunes/Dtos/ITunesAlbumDto.cs
+++ b/Jellyfin.Plugin.ITunes/Dtos/ITunesAlbumDto.cs
@@ -5,7 +5,7 @@ using System.Text.Json.Serialization;
 namespace Jellyfin.Plugin.ITunes.Dtos
 {
     /// <summary>
-    /// The ALbum DTO.
+    /// The Album DTO.
     /// </summary>
     public class ITunesAlbumDto
     {
@@ -19,14 +19,14 @@ namespace Jellyfin.Plugin.ITunes.Dtos
         }
 
         /// <summary>
-        /// Gets or sets the result count.
+        /// Gets or sets the album result count.
         /// </summary>
         /// <value>The result count.</value>
         [JsonPropertyName("resultCount")]
         public long ResultCount { get; set; }
 
         /// <summary>
-        /// Gets or sets the results.
+        /// Gets or sets the album results.
         /// </summary>
         /// <value>The results.</value>
         [JsonPropertyName("results")]

--- a/Jellyfin.Plugin.ITunes/Dtos/ITunesArtistDto.cs
+++ b/Jellyfin.Plugin.ITunes/Dtos/ITunesArtistDto.cs
@@ -19,14 +19,14 @@ namespace Jellyfin.Plugin.ITunes.Dtos
         }
 
         /// <summary>
-        /// Gets or sets the result count.
+        /// Gets or sets the artist result count.
         /// </summary>
         /// <value>The result count.</value>
         [JsonPropertyName("resultCount")]
         public long ResultCount { get; set; }
 
         /// <summary>
-        /// Gets or sets the results.
+        /// Gets or sets the artist results.
         /// </summary>
         /// <value>The results.</value>
         [JsonPropertyName("results")]

--- a/Jellyfin.Plugin.ITunes/Dtos/ITunesArtistDto.cs
+++ b/Jellyfin.Plugin.ITunes/Dtos/ITunesArtistDto.cs
@@ -1,4 +1,4 @@
-using System;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Jellyfin.Plugin.ITunes.Dtos
@@ -8,6 +8,15 @@ namespace Jellyfin.Plugin.ITunes.Dtos
     /// </summary>
     public class ITunesArtistDto
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ITunesArtistDto"/> class.
+        /// </summary>
+        public ITunesArtistDto()
+        {
+            ResultCount = 0;
+            Results = new List<ArtistResult>();
+        }
+
         /// <summary>
         /// Gets or sets the result count.
         /// </summary>
@@ -20,6 +29,6 @@ namespace Jellyfin.Plugin.ITunes.Dtos
         /// </summary>
         /// <value>The results.</value>
         [JsonPropertyName("results")]
-        public ArtistResult[] Results { get; set; } = Array.Empty<ArtistResult>();
+        public ICollection<ArtistResult> Results { get; set; }
     }
 }

--- a/Jellyfin.Plugin.ITunes/Dtos/ITunesArtistDto.cs
+++ b/Jellyfin.Plugin.ITunes/Dtos/ITunesArtistDto.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Jellyfin.Plugin.ITunes.Dtos
@@ -29,6 +30,7 @@ namespace Jellyfin.Plugin.ITunes.Dtos
         /// </summary>
         /// <value>The results.</value>
         [JsonPropertyName("results")]
+        [SuppressMessage("Usage", "CA2227", Justification = "Setter is necessary for deserialization")]
         public ICollection<ArtistResult> Results { get; set; }
     }
 }

--- a/Jellyfin.Plugin.ITunes/Jellyfin.Plugin.ITunes.csproj
+++ b/Jellyfin.Plugin.ITunes/Jellyfin.Plugin.ITunes.csproj
@@ -13,6 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AngleSharp" Version="1.0.1" />
+    <PackageReference Include="AngleSharp.XPath" Version="2.0.1" />
     <PackageReference Include="Jellyfin.Controller" Version="10.8.0" />
     <PackageReference Include="Jellyfin.Model" Version="10.8.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />

--- a/Jellyfin.Plugin.ITunes/Jellyfin.Plugin.ITunes.csproj
+++ b/Jellyfin.Plugin.ITunes/Jellyfin.Plugin.ITunes.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.ITunes</RootNamespace>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <FileVersion>2.0.0.0</FileVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
@@ -15,11 +15,11 @@
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.0.1" />
     <PackageReference Include="AngleSharp.XPath" Version="2.0.1" />
-    <PackageReference Include="Jellyfin.Controller" Version="10.8.0" />
-    <PackageReference Include="Jellyfin.Model" Version="10.8.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
+    <PackageReference Include="Jellyfin.Model" Version="10.*-*" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0" PrivateAssets="All" />
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" PrivateAssets="All" />
     <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" PrivateAssets="All" />

--- a/Jellyfin.Plugin.ITunes/Jellyfin.Plugin.ITunes.csproj
+++ b/Jellyfin.Plugin.ITunes/Jellyfin.Plugin.ITunes.csproj
@@ -1,23 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.ITunes</RootNamespace>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <FileVersion>2.0.0.0</FileVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
-    <PackageReference Include="Jellyfin.Model" Version="10.*-*" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.8.0" />
+    <PackageReference Include="Jellyfin.Model" Version="10.8.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0" PrivateAssets="All" />
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" PrivateAssets="All" />
     <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" PrivateAssets="All" />

--- a/Jellyfin.Plugin.ITunes/Providers/ITunesAlbumImageProvider.cs
+++ b/Jellyfin.Plugin.ITunes/Providers/ITunesAlbumImageProvider.cs
@@ -125,7 +125,7 @@ namespace Jellyfin.Plugin.ITunesArt.Providers
 
             if (iTunesArtistDto is not null && iTunesArtistDto.ResultCount > 0)
             {
-                foreach (Result result in iTunesArtistDto.Results)
+                foreach (AlbumResult result in iTunesArtistDto.Results)
                 {
                     if (!string.IsNullOrEmpty(result.ArtworkUrl100))
                     {

--- a/Jellyfin.Plugin.ITunes/Providers/ITunesAlbumMetadataProvider.cs
+++ b/Jellyfin.Plugin.ITunes/Providers/ITunesAlbumMetadataProvider.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.ITunes.Dtos;
+using MediaBrowser.Common.Net;
+using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Providers;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.ITunes.Providers;
+
+public class ITunesAlbumMetadataProvider : IRemoteMetadataProvider<MusicAlbum, AlbumInfo>
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<ITunesArtistMetadataProvider> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ITunesAlbumMetadataProvider"/> class.
+    /// </summary>
+    /// <param name="httpClientFactory">HTTP client factory.</param>
+    /// <param name="loggerFactory">Logger factory.</param>
+    public ITunesAlbumMetadataProvider(IHttpClientFactory httpClientFactory, ILoggerFactory loggerFactory)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = loggerFactory.CreateLogger<ITunesArtistMetadataProvider>();
+    }
+
+    /// <inheritdoc />
+    public string Name => "Apple Music";
+
+    /// <inheritdoc />
+    public Task<IEnumerable<RemoteSearchResult>> GetSearchResults(AlbumInfo searchInfo, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    public async Task<MetadataResult<MusicAlbum>> GetMetadata(AlbumInfo info, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(info.Name))
+        {
+            _logger.LogDebug("Empty album name, skipping");
+            return EmptyResult();
+        }
+
+        var albumArtist = info.AlbumArtists.FirstOrDefault(string.Empty);
+        return await GetMetadataInternal(GetSearchUrl(info.Name, albumArtist), cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<HttpResponseMessage> GetImageResponse(string url, CancellationToken cancellationToken)
+    {
+        var httpClient = _httpClientFactory.CreateClient(NamedClient.Default);
+        return await httpClient.GetAsync(new Uri(url), cancellationToken).ConfigureAwait(false);
+    }
+
+    private static MetadataResult<MusicAlbum> EmptyResult()
+    {
+        return new MetadataResult<MusicAlbum>
+        {
+            Item = new MusicAlbum(),
+            HasMetadata = false
+        };
+    }
+
+    private static string GetSearchUrl(string albumName, string artistName)
+    {
+        var encodedName = Uri.EscapeDataString($"{artistName} {albumName}");
+        return $"https://itunes.apple.com/search?term={encodedName}&media=music&entity=album&attribute=albumTerm";
+    }
+
+    private async Task<MetadataResult<MusicAlbum>> GetMetadataInternal(string url, CancellationToken cancellationToken)
+    {
+        var iTunesAlbumDto = await _httpClientFactory
+            .CreateClient(NamedClient.Default)
+            .GetFromJsonAsync<ITunesAlbumDto>(new Uri(url), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (iTunesAlbumDto is null || iTunesAlbumDto.ResultCount < 1)
+        {
+            _logger.LogDebug("No results for url {Url}", url);
+            return EmptyResult();
+        }
+
+        var result = iTunesAlbumDto.Results.First();
+        if (result.CollectionViewUrl is null)
+        {
+            _logger.LogDebug("No album links found in results");
+            return EmptyResult();
+        }
+
+        _logger.LogDebug("Using {Url} to fetch album data", result.CollectionViewUrl);
+
+        var musicAlbum = new MusicAlbum
+        {
+            Name = result.CollectionName,
+            MusicArtist = { Name = result.ArtistName }
+        };
+
+        return new MetadataResult<MusicAlbum>
+        {
+            Item = musicAlbum,
+            HasMetadata = true,
+            RemoteImages = GetAlbumImages(result)
+        };
+    }
+
+    private static List<(string Url, ImageType Type)> GetAlbumImages(Result album)
+    {
+        if (album.ArtworkUrl100 is null)
+        {
+            return new List<(string Url, ImageType Type)>();
+        }
+
+        var primaryImageUrl = album.ArtworkUrl100.Replace("100x100bb", "1400x1400bb", StringComparison.OrdinalIgnoreCase);
+        return new List<(string Url, ImageType Type)>
+        {
+            (primaryImageUrl, ImageType.Primary),
+            (album.ArtworkUrl100, ImageType.Thumb)
+        };
+    }
+}

--- a/Jellyfin.Plugin.ITunes/Providers/ITunesAlbumMetadataProvider.cs
+++ b/Jellyfin.Plugin.ITunes/Providers/ITunesAlbumMetadataProvider.cs
@@ -148,7 +148,7 @@ public class ITunesAlbumMetadataProvider : IRemoteMetadataProvider<MusicAlbum, A
         };
     }
 
-    private static List<(string Url, ImageType Type)> GetAlbumImages(Result album)
+    private static List<(string Url, ImageType Type)> GetAlbumImages(AlbumResult album)
     {
         if (album.ArtworkUrl100 is null)
         {

--- a/Jellyfin.Plugin.ITunes/Providers/ITunesAlbumMetadataProvider.cs
+++ b/Jellyfin.Plugin.ITunes/Providers/ITunesAlbumMetadataProvider.cs
@@ -21,7 +21,7 @@ namespace Jellyfin.Plugin.ITunes.Providers;
 public class ITunesAlbumMetadataProvider : IRemoteMetadataProvider<MusicAlbum, AlbumInfo>
 {
     private readonly IHttpClientFactory _httpClientFactory;
-    private readonly ILogger<ITunesArtistMetadataProvider> _logger;
+    private readonly ILogger<ITunesAlbumMetadataProvider> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ITunesAlbumMetadataProvider"/> class.
@@ -31,7 +31,7 @@ public class ITunesAlbumMetadataProvider : IRemoteMetadataProvider<MusicAlbum, A
     public ITunesAlbumMetadataProvider(IHttpClientFactory httpClientFactory, ILoggerFactory loggerFactory)
     {
         _httpClientFactory = httpClientFactory;
-        _logger = loggerFactory.CreateLogger<ITunesArtistMetadataProvider>();
+        _logger = loggerFactory.CreateLogger<ITunesAlbumMetadataProvider>();
     }
 
     /// <inheritdoc />

--- a/Jellyfin.Plugin.ITunes/Providers/ITunesAlbumMetadataProvider.cs
+++ b/Jellyfin.Plugin.ITunes/Providers/ITunesAlbumMetadataProvider.cs
@@ -27,11 +27,11 @@ public class ITunesAlbumMetadataProvider : IRemoteMetadataProvider<MusicAlbum, A
     /// Initializes a new instance of the <see cref="ITunesAlbumMetadataProvider"/> class.
     /// </summary>
     /// <param name="httpClientFactory">HTTP client factory.</param>
-    /// <param name="loggerFactory">Logger factory.</param>
-    public ITunesAlbumMetadataProvider(IHttpClientFactory httpClientFactory, ILoggerFactory loggerFactory)
+    /// <param name="logger">Logger instance.</param>
+    public ITunesAlbumMetadataProvider(IHttpClientFactory httpClientFactory, ILogger<ITunesAlbumMetadataProvider> logger)
     {
         _httpClientFactory = httpClientFactory;
-        _logger = loggerFactory.CreateLogger<ITunesAlbumMetadataProvider>();
+        _logger = logger;
     }
 
     /// <inheritdoc />

--- a/Jellyfin.Plugin.ITunes/Providers/ITunesAlbumMetadataProvider.cs
+++ b/Jellyfin.Plugin.ITunes/Providers/ITunesAlbumMetadataProvider.cs
@@ -69,7 +69,7 @@ public class ITunesAlbumMetadataProvider : IRemoteMetadataProvider<MusicAlbum, A
             var albumImages = GetAlbumImages(albumDto);
             results.Add(new RemoteSearchResult
             {
-                Name = albumDto.ArtistName,
+                Name = albumDto.CollectionName,
                 ImageUrl = albumImages.FirstOrDefault((string.Empty, ImageType.Thumb)).Item1
             });
         }

--- a/Jellyfin.Plugin.ITunes/Providers/ITunesAlbumMetadataProvider.cs
+++ b/Jellyfin.Plugin.ITunes/Providers/ITunesAlbumMetadataProvider.cs
@@ -158,8 +158,7 @@ public class ITunesAlbumMetadataProvider : IRemoteMetadataProvider<MusicAlbum, A
         var primaryImageUrl = album.ArtworkUrl100.Replace("100x100bb", "1400x1400bb", StringComparison.OrdinalIgnoreCase);
         return new List<(string Url, ImageType Type)>
         {
-            (primaryImageUrl, ImageType.Primary),
-            (album.ArtworkUrl100, ImageType.Thumb)
+            (primaryImageUrl, ImageType.Primary)
         };
     }
 }

--- a/Jellyfin.Plugin.ITunes/Providers/ITunesArtistMetadataProvider.cs
+++ b/Jellyfin.Plugin.ITunes/Providers/ITunesArtistMetadataProvider.cs
@@ -175,15 +175,12 @@ public class ITunesArtistMetadataProvider : IRemoteMetadataProvider<MusicArtist,
         // The artwork size can vary quite a bit, but for our uses, 1400x1400 should be plenty.
         // https://artists.apple.com/support/88-artist-image-guidelines
         var primaryImageUrl = artistImage.TextContent.Replace("1200x630cw", "1400x1400cc", StringComparison.OrdinalIgnoreCase);
-        var thumbImageUrl = artistImage.TextContent.Replace("1200x630cw", "100x100cc", StringComparison.OrdinalIgnoreCase);
 
         _logger.LogDebug("Found primary image at: {Primary}", primaryImageUrl);
-        _logger.LogDebug("Found thumbnail image at: {Thumbnail}", thumbImageUrl);
 
         return new List<(string Url, ImageType Type)>
         {
-            (primaryImageUrl, ImageType.Primary),
-            (thumbImageUrl, ImageType.Thumb)
+            (primaryImageUrl, ImageType.Primary)
         };
     }
 }

--- a/Jellyfin.Plugin.ITunes/Providers/ITunesArtistMetadataProvider.cs
+++ b/Jellyfin.Plugin.ITunes/Providers/ITunesArtistMetadataProvider.cs
@@ -30,11 +30,11 @@ public class ITunesArtistMetadataProvider : IRemoteMetadataProvider<MusicArtist,
     /// Initializes a new instance of the <see cref="ITunesArtistMetadataProvider"/> class.
     /// </summary>
     /// <param name="httpClientFactory">HTTP client factory.</param>
-    /// <param name="loggerFactory">Logger factory.</param>
-    public ITunesArtistMetadataProvider(IHttpClientFactory httpClientFactory, ILoggerFactory loggerFactory)
+    /// <param name="logger">Logger instance.</param>
+    public ITunesArtistMetadataProvider(IHttpClientFactory httpClientFactory, ILogger<ITunesArtistMetadataProvider> logger)
     {
         _httpClientFactory = httpClientFactory;
-        _logger = loggerFactory.CreateLogger<ITunesArtistMetadataProvider>();
+        _logger = logger;
         _config = AngleSharp.Configuration.Default.WithDefaultLoader();
     }
 

--- a/Jellyfin.Plugin.ITunes/Providers/ITunesArtistMetadataProvider.cs
+++ b/Jellyfin.Plugin.ITunes/Providers/ITunesArtistMetadataProvider.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using HtmlAgilityPack;
+using Jellyfin.Plugin.ITunes.Dtos;
+using MediaBrowser.Common.Net;
+using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Providers;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.ITunes.Providers;
+
+/// <summary>
+/// The iTunes artist metadata provider.
+/// </summary>
+public class ITunesArtistMetadataProvider : IRemoteMetadataProvider<MusicArtist, ArtistInfo>
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<ITunesArtistMetadataProvider> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ITunesArtistMetadataProvider"/> class.
+    /// </summary>
+    /// <param name="httpClientFactory">HTTP client factory.</param>
+    /// <param name="loggerFactory">Logger factory.</param>
+    public ITunesArtistMetadataProvider(IHttpClientFactory httpClientFactory, ILoggerFactory loggerFactory)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = loggerFactory.CreateLogger<ITunesArtistMetadataProvider>();
+    }
+
+    /// <inheritdoc />
+    public string Name => "Apple Music";
+
+    /// <inheritdoc />
+    public async Task<MetadataResult<MusicArtist>> GetMetadata(ArtistInfo info, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(info.Name))
+        {
+            _logger.LogDebug("Empty artist name, skipping");
+            return EmptyResult();
+        }
+
+        var encodedName = Uri.EscapeDataString(info.Name);
+        return await GetMetadataInternal(
+            $"https://itunes.apple.com/search?term=${encodedName}&media=music&entity=musicArtist&attribute=artistTerm",
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public Task<IEnumerable<RemoteSearchResult>> GetSearchResults(ArtistInfo searchInfo, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    public async Task<HttpResponseMessage> GetImageResponse(string url, CancellationToken cancellationToken)
+    {
+        var httpClient = _httpClientFactory.CreateClient(NamedClient.Default);
+        return await httpClient.GetAsync(new Uri(url), cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<MetadataResult<MusicArtist>> GetMetadataInternal(string url, CancellationToken cancellationToken)
+    {
+        var iTunesArtistDto = await _httpClientFactory
+            .CreateClient(NamedClient.Default)
+            .GetFromJsonAsync<ITunesArtistDto>(new Uri(url), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (iTunesArtistDto is null || iTunesArtistDto.ResultCount < 1)
+        {
+            _logger.LogDebug("No results for url {Url}", url);
+            return EmptyResult();
+        }
+
+        var result = iTunesArtistDto.Results.First();
+        if (result.ArtistLinkUrl is null)
+        {
+            _logger.LogDebug("No artist links found in results");
+            return EmptyResult();
+        }
+
+        _logger.LogDebug("URL: {Url}", result.ArtistLinkUrl);
+
+        HtmlWeb web = new HtmlWeb();
+        var doc = web.Load(new Uri(result.ArtistLinkUrl));
+        if (doc?.CreateNavigator() is not HtmlNodeNavigator navigator)
+        {
+            _logger.LogDebug("Failed to create a scraping navigator");
+            return EmptyResult();
+        }
+
+        var aboutArtistNode = navigator.SelectSingleNode("//p[@data-testid=\"content-modal-text\"]");
+        if (aboutArtistNode is null)
+        {
+            _logger.LogDebug("Failed to get full about artist node, will fall back to truncated");
+            aboutArtistNode = navigator.SelectSingleNode("//p[@data-testid=\"trruncate-text\"]");
+        }
+
+        if (aboutArtistNode is null)
+        {
+            _logger.LogDebug("Failed to get truncated about artist, giving up");
+            return EmptyResult();
+        }
+
+        var musicArtist = new MusicArtist { Overview = aboutArtistNode.Value };
+        return new MetadataResult<MusicArtist>
+        {
+            Item = musicArtist,
+            HasMetadata = true,
+        };
+    }
+
+    private static MetadataResult<MusicArtist> EmptyResult()
+    {
+        return new MetadataResult<MusicArtist>
+        {
+            Item = new MusicArtist(),
+            HasMetadata = false
+        };
+    }
+}

--- a/Jellyfin.Plugin.ITunes/Providers/ITunesArtistMetadataProvider.cs
+++ b/Jellyfin.Plugin.ITunes/Providers/ITunesArtistMetadataProvider.cs
@@ -81,14 +81,11 @@ public class ITunesArtistMetadataProvider : IRemoteMetadataProvider<MusicArtist,
             }
 
             var artistInfo = await GetArtistInfo(artistDto.ArtistLinkUrl, cancellationToken).ConfigureAwait(false);
-            if (artistInfo is not null)
+            results.Add(new RemoteSearchResult
             {
-                results.Add(new RemoteSearchResult
-                {
-                    Name = artistDto.ArtistName,
-                    Overview = artistInfo
-                });
-            }
+                Name = artistDto.ArtistName,
+                Overview = artistInfo ?? string.Empty
+            });
         }
 
         return results;

--- a/Jellyfin.Plugin.ITunes/Providers/ITunesArtistMetadataProvider.cs
+++ b/Jellyfin.Plugin.ITunes/Providers/ITunesArtistMetadataProvider.cs
@@ -99,7 +99,7 @@ public class ITunesArtistMetadataProvider : IRemoteMetadataProvider<MusicArtist,
         if (aboutArtistNode is null)
         {
             _logger.LogDebug("Failed to get full about artist node, will fall back to truncated");
-            aboutArtistNode = navigator.SelectSingleNode("//p[@data-testid=\"trruncate-text\"]");
+            aboutArtistNode = navigator.SelectSingleNode("//p[@data-testid=\"truncate-text\"]");
         }
 
         if (aboutArtistNode is null)

--- a/Jellyfin.Plugin.ITunes/Providers/ITunesArtistMetadataProvider.cs
+++ b/Jellyfin.Plugin.ITunes/Providers/ITunesArtistMetadataProvider.cs
@@ -135,7 +135,7 @@ public class ITunesArtistMetadataProvider : IRemoteMetadataProvider<MusicArtist,
         {
             Item = musicArtist,
             HasMetadata = true,
-            RemoteImages = await GetArtistImages(url, cancellationToken).ConfigureAwait(false)
+            RemoteImages = await GetArtistImages(result.ArtistLinkUrl, cancellationToken).ConfigureAwait(false)
         };
     }
 

--- a/Jellyfin.Plugin.ITunes/Providers/ITunesArtistMetadataProvider.cs
+++ b/Jellyfin.Plugin.ITunes/Providers/ITunesArtistMetadataProvider.cs
@@ -82,10 +82,12 @@ public class ITunesArtistMetadataProvider : IRemoteMetadataProvider<MusicArtist,
             }
 
             var artistInfo = await GetArtistInfo(artistDto.ArtistLinkUrl, cancellationToken).ConfigureAwait(false);
+            var artistImages = await GetArtistImages(artistDto.ArtistLinkUrl, cancellationToken).ConfigureAwait(false);
             results.Add(new RemoteSearchResult
             {
                 Name = artistDto.ArtistName,
-                Overview = artistInfo ?? string.Empty
+                Overview = artistInfo ?? string.Empty,
+                ImageUrl = artistImages.FirstOrDefault((string.Empty, ImageType.Thumb)).Item1
             });
         }
 

--- a/Jellyfin.Plugin.ITunes/Providers/ITunesArtistMetadataProvider.cs
+++ b/Jellyfin.Plugin.ITunes/Providers/ITunesArtistMetadataProvider.cs
@@ -88,7 +88,7 @@ public class ITunesArtistMetadataProvider : IRemoteMetadataProvider<MusicArtist,
             return EmptyResult();
         }
 
-        _logger.LogDebug("URL: {Url}", result.ArtistLinkUrl);
+        _logger.LogDebug("Using {Url} to fetch artist info", result.ArtistLinkUrl);
 
         var context = BrowsingContext.New(_config);
         var doc = await context.OpenAsync(result.ArtistLinkUrl, cancellationToken).ConfigureAwait(false);

--- a/Jellyfin.Plugin.ITunes/Providers/ITunesArtistMetadataProvider.cs
+++ b/Jellyfin.Plugin.ITunes/Providers/ITunesArtistMetadataProvider.cs
@@ -92,7 +92,7 @@ public class ITunesArtistMetadataProvider : IRemoteMetadataProvider<MusicArtist,
 
         var context = BrowsingContext.New(_config);
         var doc = await context.OpenAsync(result.ArtistLinkUrl, cancellationToken).ConfigureAwait(false);
-        var artistInfo = doc.Body.SelectSingleNode("//p[@data-testid=\"truncate-text\"]");
+        var artistInfo = doc.Body.SelectSingleNode("//p[@data-testid='truncate-text']");
         if (artistInfo is null)
         {
             _logger.LogDebug("Failed to get about artist info");

--- a/Jellyfin.Plugin.ITunes/Providers/ITunesArtistMetadataProvider.cs
+++ b/Jellyfin.Plugin.ITunes/Providers/ITunesArtistMetadataProvider.cs
@@ -95,16 +95,10 @@ public class ITunesArtistMetadataProvider : IRemoteMetadataProvider<MusicArtist,
             return EmptyResult();
         }
 
-        var aboutArtistNode = navigator.SelectSingleNode("//p[@data-testid=\"content-modal-text\"]");
+        var aboutArtistNode = navigator.SelectSingleNode("//p[@data-testid=\"truncate-text\"]");
         if (aboutArtistNode is null)
         {
-            _logger.LogDebug("Failed to get full about artist node, will fall back to truncated");
-            aboutArtistNode = navigator.SelectSingleNode("//p[@data-testid=\"truncate-text\"]");
-        }
-
-        if (aboutArtistNode is null)
-        {
-            _logger.LogDebug("Failed to get truncated about artist, giving up");
+            _logger.LogDebug("Failed to get about artist info");
             return EmptyResult();
         }
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Currently supported:
 
 ## Build
 
-1. To build this plugin you will need [.Net 6.x](https://dotnet.microsoft.com/download/dotnet/6.0).
+1. To build this plugin you will need [.Net 7.x](https://dotnet.microsoft.com/download/dotnet/7.0).
 
 2. Build plugin with following command
   ```

--- a/README.md
+++ b/README.md
@@ -9,11 +9,13 @@
 [![Current Release](https://img.shields.io/github/release/Shadowghost/jellyfin-plugin-itunes.svg)](https://github.com/Shadowghost/jellyfin-plugin-itunes/releases)
 
 ## About
-Fetches Metadata from iTunes
+Fetches Metadata from iTunes (Apple Music)
 
 Currently supported:
 * Album Images
 * Artist Images
+* Artist Info (Overview)
+* Identifying albums and artists
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Currently supported:
   dotnet publish --configuration Release --output bin
   ```
 
-3. Place the dll-file in the `plugins/coverartarchive` folder (you might need to create the folders) of your JF install
+3. Place the dll-file in the `plugins/itunes` folder (you might need to create the folders) of your JF install
 
 ## Releasing
 


### PR DESCRIPTION
This pull request implements album and artist metadata fetching, as well as being able to identify artist and album using the Jellyfin UI.

I opted to use `AngleSharp` library for reading the HTML DOM as `HtmlAgilityPack` was not happy with some special characters in the artist info text. It'd be nice if the plugin used single library for everything, but I did not want to increase the scope. It can be always cleaned up later.

Also I'm not sure about the distribution of 3rd party dependencies together with plugin, but since there was already `HtmlAgilityPack`, I think there should be no problems with that.

In addition to these changes, I also fixed warnings and did some minor code cleanup and refactoring. I'd have done more, but as I said earlier, I wanted to limit the scope of the changes.

### Some screenshots

#### Metadata sources:
<img width="815" alt="image" src="https://user-images.githubusercontent.com/26324629/236525806-d54f8df6-56b0-4b63-8383-6b7219967fa9.png">

#### Identifying album
<img width="852" alt="image" src="https://user-images.githubusercontent.com/26324629/236527386-734e4698-f072-45ae-9a81-231fd11ca1f3.png">

#### Identifying artist
<img width="858" alt="image" src="https://user-images.githubusercontent.com/26324629/236526460-c550d685-c1d6-4de4-9940-eafd1ea3af61.png">

Tested with Jellyfin 10.8.x (locally downgraded the project to be compatible)

Let me know if you need anything. Thank you.